### PR TITLE
Fix the bug: "openssl ca" signing CSR with "-rand_serial" should not update serial file

### DIFF
--- a/apps/ca.c
+++ b/apps/ca.c
@@ -1063,7 +1063,7 @@ end_of_options:
             BIO_printf(bio_err, "Write out database with %d new entries\n",
                        sk_X509_num(cert_sk));
 
-            if (serialfile != NULL
+            if (serialfile != NULL && !rand_ser
                     && !save_serial(serialfile, "new", serial, NULL))
                 goto end;
 
@@ -1131,7 +1131,7 @@ end_of_options:
 
         if (sk_X509_num(cert_sk)) {
             /* Rename the database and the serial file */
-            if (serialfile != NULL
+            if (serialfile != NULL && !rand_ser
                     && !rotate_serial(serialfile, "new", "old"))
                 goto end;
 


### PR DESCRIPTION
**The bug:** when serial file is specified in configuration, invocation of `openssl ca` for signing a CRS with option `-rand_serial` still updates random serial number to serial file. This doesn't make sense since serial file serves for the incremental update of serial number in sequence of certificates signing. The help text for `openssl ca` command says for `-rand_serial` option "Always create a random serial; do not store it" so the current behavior also contradicts the documented. 

**The fix:** when `-rand_serial` is specified serial file is not updated